### PR TITLE
Add DNS Tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/terraform-providers/terraform-provider-statuscake
 go 1.14
 
 require (
-	github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb
+	github.com/DreamItGetIT/statuscake v0.0.0-20201021084627-4e32615dcae9
 	github.com/hashicorp/terraform v0.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNf
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb h1:vJ3lnCyZNmSV/OKyw4d7GuZHFrUaa3FY6/NqtvRE0lw=
 github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb/go.mod h1:OclNh7ZacJo61GDJablmsOZ7l8/AVtzGqP8G7baOdAs=
+github.com/DreamItGetIT/statuscake v0.0.0-20201021084627-4e32615dcae9 h1:mAqrNxLrhgFL6U+YoDhOa/7jz3xlvtOowsaBMiBUkRU=
+github.com/DreamItGetIT/statuscake v0.0.0-20201021084627-4e32615dcae9/go.mod h1:OclNh7ZacJo61GDJablmsOZ7l8/AVtzGqP8G7baOdAs=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 h1:tuQ7w+my8a8mkwN7x2TSd7OzTjkZ7rAeSyH4xncuAMI=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=

--- a/statuscake/resource_statuscaketest.go
+++ b/statuscake/resource_statuscaketest.go
@@ -228,6 +228,16 @@ func resourceStatusCakeTest() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+
+			"dns_server": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"dns_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -268,6 +278,8 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		FinalEndpoint:  d.Get("final_endpoint").(string),
 		EnableSSLAlert: d.Get("enable_ssl_alert").(bool),
 		FollowRedirect: d.Get("follow_redirect").(bool),
+		DNSServer:      d.Get("dns_server").(string),
+		DNSIP:          d.Get("dns_ip").(string),
 	}
 
 	if v, ok := d.GetOk("contact_group"); ok {
@@ -366,6 +378,8 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("final_endpoint", testResp.FinalEndpoint)
 	d.Set("enable_ssl_alert", testResp.EnableSSLAlert)
 	d.Set("follow_redirect", testResp.FollowRedirect)
+	d.Set("dns_server", testResp.DNSServer)
+	d.Set("dns_ip", testResp.DNSIP)
 
 	return nil
 }
@@ -472,6 +486,12 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("follow_redirect"); ok {
 		test.FollowRedirect = v.(bool)
+	}
+	if v, ok := d.GetOk("dns_server"); ok {
+		test.DNSServer = v.(string)
+	}
+	if v, ok := d.GetOk("dns_ip"); ok {
+		test.DNSIP = v.(string)
 	}
 
 	return test

--- a/statuscake/resource_statuscaketest_test.go
+++ b/statuscake/resource_statuscaketest_test.go
@@ -68,6 +68,25 @@ func TestAccStatusCake_tcp(t *testing.T) {
 	})
 }
 
+func TestAccStatusCake_dns(t *testing.T) {
+	var test statuscake.Test
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccTestCheckDestroy(&test),
+		Steps: []resource.TestStep{
+			{
+				Config: interpolateTerraformTemplate(testAccTestConfig_dns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccTestCheckExists("statuscake_test.google", &test),
+					testAccTestCheckAttributes("statuscake_test.google", &test),
+				),
+			},
+		},
+	})
+}
+
 func TestAccStatusCake_withUpdate(t *testing.T) {
 	var test statuscake.Test
 
@@ -218,6 +237,10 @@ func testAccTestCheckAttributes(rn string, test *statuscake.Test) resource.TestC
 				err = check(key, value, strconv.FormatBool(test.EnableSSLAlert))
 			case "follow_redirect":
 				err = check(key, value, strconv.FormatBool(test.FollowRedirect))
+			case "dns_server":
+				err = check(key, value, test.DNSServer)
+			case "dns_ip":
+				err = check(key, value, test.DNSIP)
 			}
 			if err != nil {
 				return err
@@ -315,5 +338,17 @@ resource "statuscake_test" "google" {
 	contact_group = ["%s"]
 	confirmations = 1
 	port = 80
+}
+`
+const testAccTestConfig_dns = `
+resource "statuscake_test" "google" {
+	website_url = "dns.google"
+	dns_server = "1.1.1.1"
+	dns_ip = "8.8.8.8,8.8.4.4"
+	test_type = "DNS"
+	check_rate = 300
+	timeout = 10
+	contact_group = ["%s"]
+	confirmations = 1
 }
 `

--- a/vendor/github.com/DreamItGetIT/statuscake/Gopkg.lock
+++ b/vendor/github.com/DreamItGetIT/statuscake/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  pruneopts = "UT"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -30,7 +38,7 @@
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require",
+    "require"
   ]
   pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
@@ -41,8 +49,9 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DreamItGetIT/statuscake",
+    "github.com/google/go-querystring/query",
     "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/require",
+    "github.com/stretchr/testify/require"
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/DreamItGetIT/statuscake/contactGroups.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/contactGroups.go
@@ -1,0 +1,149 @@
+package statuscake
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/google/go-querystring/query"
+)
+
+//ContactGroup represent the data received by the API with GET
+type ContactGroup struct {
+	GroupName    string   `json:"GroupName"    url:"GroupName,omitempty"`
+	Emails       []string `json:"Emails"`
+	EmailsPut    string   `url:"Email,omitempty"`
+	Mobiles      string   `json:"Mobiles"      url:"Mobile,omitempty"`
+	Boxcar       string   `json:"Boxcar"       url:"Boxcar,omitempty"`
+	Pushover     string   `json:"Pushover"     url:"Pushover,omitempty"`
+	ContactID    int      `json:"ContactID"    url:"ContactID,omitempty"`
+	DesktopAlert string   `json:"DesktopAlert" url:"DesktopAlert,omitempty"`
+	PingURL      string   `json:"PingURL"      url:"PingURL,omitempty"`
+}
+
+//Response represent the data received from the API
+type Response struct {
+	Success  bool   `json:"Success"`
+	Message  string `json:"Message"`
+	InsertID int    `json:"InsertID"`
+}
+
+//ContactGroups represent the actions done with the API
+type ContactGroups interface {
+	All() ([]*ContactGroup, error)
+	Detail(int) (*ContactGroup, error)
+	Update(*ContactGroup) (*ContactGroup, error)
+	Delete(int) error
+	Create(*ContactGroup) (*ContactGroup, error)
+}
+
+func findContactGroup(responses []*ContactGroup, id int) (*ContactGroup, error) {
+	var response *ContactGroup
+	for _, elem := range responses {
+		if (*elem).ContactID == id {
+			return elem, nil
+		}
+	}
+	return response, fmt.Errorf("%d Not found", id)
+}
+
+type contactGroups struct {
+	client apiClient
+}
+
+//NewContactGroups return a new ssls
+func NewContactGroups(c apiClient) ContactGroups {
+	return &contactGroups{
+		client: c,
+	}
+}
+
+//All return a list of all the ContactGroup from the API
+func (tt *contactGroups) All() ([]*ContactGroup, error) {
+	rawResponse, err := tt.client.get("/ContactGroups", nil)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting StatusCake contactGroups: %s", err.Error())
+	}
+	var getResponse []*ContactGroup
+	err = json.NewDecoder(rawResponse.Body).Decode(&getResponse)
+	if err != nil {
+		return nil, err
+	}
+	return getResponse, err
+}
+
+//Detail return the ContactGroup corresponding to the id
+func (tt *contactGroups) Detail(id int) (*ContactGroup, error) {
+	responses, err := tt.All()
+	if err != nil {
+		return nil, err
+	}
+	myContactGroup, errF := findContactGroup(responses, id)
+	if errF != nil {
+		return nil, errF
+	}
+	return myContactGroup, nil
+}
+
+//Update update the API with cg and create one if cg.ContactID=0 then return the corresponding ContactGroup
+func (tt *contactGroups) Update(cg *ContactGroup) (*ContactGroup, error) {
+
+	if cg.ContactID == 0 {
+		return tt.Create(cg)
+	}
+	cg.EmailsPut = strings.Join(cg.Emails, ",")
+	var v url.Values
+
+	v, _ = query.Values(*cg)
+
+	rawResponse, err := tt.client.put("/ContactGroups/Update", v)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating StatusCake ContactGroup: %s", err.Error())
+	}
+
+	var response Response
+	err = json.NewDecoder(rawResponse.Body).Decode(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("%s", response.Message)
+	}
+
+	return cg, nil
+}
+
+//Delete delete the ContactGroup which ID is id
+func (tt *contactGroups) Delete(id int) error {
+	_, err := tt.client.delete("/ContactGroups/Update", url.Values{"ContactID": {fmt.Sprint(id)}})
+	return err
+}
+
+//CreatePartial create the ContactGroup whith the data in cg and return the ContactGroup created
+func (tt *contactGroups) Create(cg *ContactGroup) (*ContactGroup, error) {
+	cg.ContactID = 0
+	cg.EmailsPut = strings.Join(cg.Emails, ",")
+	var v url.Values
+	v, _ = query.Values(*cg)
+
+	rawResponse, err := tt.client.put("/ContactGroups/Update", v)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating StatusCake ContactGroup: %s", err.Error())
+	}
+
+	var response Response
+	err = json.NewDecoder(rawResponse.Body).Decode(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("%s", response.Message)
+	}
+
+	cg.ContactID = response.InsertID
+
+	return cg, nil
+}

--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -29,41 +29,45 @@ type contactGroupDetailResponse struct {
 }
 
 type detailResponse struct {
-	Method          string                       `json:"Method"`
-	TestID          int                          `json:"TestID"`
-	TestType        string                       `json:"TestType"`
-	Paused          bool                         `json:"Paused"`
-	WebsiteName     string                       `json:"WebsiteName"`
-	URI             string                       `json:"URI"`
-	ContactID       int                          `json:"ContactID"`
-	ContactGroups   []contactGroupDetailResponse `json:"ContactGroups"`
-	Status          string                       `json:"Status"`
-	Uptime          float64                      `json:"Uptime"`
-	CustomHeader    string                       `json:"CustomHeader"`
-	UserAgent       string                       `json:"UserAgent"`
-	CheckRate       int                          `json:"CheckRate"`
-	Timeout         int                          `json:"Timeout"`
-	LogoImage       string                       `json:"LogoImage"`
-	Confirmation    int                          `json:"Confirmation,string"`
-	WebsiteHost     string                       `json:"WebsiteHost"`
-	NodeLocations   []string                     `json:"NodeLocations"`
-	FindString      string                       `json:"FindString"`
-	DoNotFind       bool                         `json:"DoNotFind"`
-	LastTested      string                       `json:"LastTested"`
-	NextLocation    string                       `json:"NextLocation"`
-	Port            int                          `json:"Port"`
-	Processing      bool                         `json:"Processing"`
-	ProcessingState string                       `json:"ProcessingState"`
-	ProcessingOn    string                       `json:"ProcessingOn"`
-	DownTimes       int                          `json:"DownTimes,string"`
-	Sensitive       bool                         `json:"Sensitive"`
-	TriggerRate     int                          `json:"TriggerRate,string"`
-	UseJar          int                          `json:"UseJar"`
-	PostRaw         string                       `json:"PostRaw"`
-	FinalEndpoint   string                       `json:"FinalEndpoint"`
-	EnableSSLWarning  bool                       `json:"EnableSSLWarning"`
-	FollowRedirect  bool                         `json:"FollowRedirect"`
-	StatusCodes     []string                     `json:"StatusCodes"`
+	Method           string                       `json:"Method"`
+	TestID           int                          `json:"TestID"`
+	TestType         string                       `json:"TestType"`
+	Paused           bool                         `json:"Paused"`
+	WebsiteName      string                       `json:"WebsiteName"`
+	URI              string                       `json:"URI"`
+	ContactID        int                          `json:"ContactID"`
+	ContactGroups    []contactGroupDetailResponse `json:"ContactGroups"`
+	Status           string                       `json:"Status"`
+	Uptime           float64                      `json:"Uptime"`
+	CustomHeader     string                       `json:"CustomHeader"`
+	UserAgent        string                       `json:"UserAgent"`
+	CheckRate        int                          `json:"CheckRate"`
+	Timeout          int                          `json:"Timeout"`
+	LogoImage        string                       `json:"LogoImage"`
+	Confirmation     int                          `json:"Confirmation,string"`
+	WebsiteHost      string                       `json:"WebsiteHost"`
+	NodeLocations    []string                     `json:"NodeLocations"`
+	FindString       string                       `json:"FindString"`
+	DoNotFind        bool                         `json:"DoNotFind"`
+	LastTested       string                       `json:"LastTested"`
+	NextLocation     string                       `json:"NextLocation"`
+	Port             int                          `json:"Port"`
+	Processing       bool                         `json:"Processing"`
+	ProcessingState  string                       `json:"ProcessingState"`
+	ProcessingOn     string                       `json:"ProcessingOn"`
+	DownTimes        int                          `json:"DownTimes,string"`
+	Sensitive        bool                         `json:"Sensitive"`
+	TriggerRate      int                          `json:"TriggerRate,string"`
+	UseJar           int                          `json:"UseJar"`
+	PostRaw          string                       `json:"PostRaw"`
+	PostBody         string                       `json:"PostBody"`
+	FinalEndpoint    string                       `json:"FinalEndpoint"`
+	EnableSSLWarning bool                         `json:"EnableSSLWarning"`
+	FollowRedirect   bool                         `json:"FollowRedirect"`
+	DNSServer        string                       `json:"DNSServer"`
+	DNSIP            string                       `json:"DNSIP"`
+	StatusCodes      []string                     `json:"StatusCodes"`
+	Tags             []string                     `json:"Tags"`
 }
 
 func (d *detailResponse) test() *Test {
@@ -96,9 +100,13 @@ func (d *detailResponse) test() *Test {
 		TriggerRate:    d.TriggerRate,
 		UseJar:         d.UseJar,
 		PostRaw:        d.PostRaw,
+		PostBody:       d.PostBody,
 		FinalEndpoint:  d.FinalEndpoint,
+		DNSServer:      d.DNSServer,
+		DNSIP:          d.DNSIP,
 		EnableSSLAlert: d.EnableSSLWarning,
 		FollowRedirect: d.FollowRedirect,
 		StatusCodes:    strings.Join(d.StatusCodes[:], ","),
+		TestTags:       d.Tags,
 	}
 }

--- a/vendor/github.com/DreamItGetIT/statuscake/ssl.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/ssl.go
@@ -1,0 +1,325 @@
+package statuscake
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-querystring/query"
+)
+
+//Ssl represent the data received by the API with GET
+type Ssl struct {
+	ID             string              `json:"id"                 url:"id,omitempty"`
+	Domain         string              `json:"domain"             url:"domain,omitempty"`
+	Checkrate      int                 `json:"checkrate"          url:"checkrate,omitempty"`
+	ContactGroupsC string              `                          url:"contact_groups,omitempty"`
+	AlertAt        string              `json:"alert_at"           url:"alert_at,omitempty"`
+	AlertReminder  bool                `json:"alert_reminder"     url:"alert_expiry,omitempty"`
+	AlertExpiry    bool                `json:"alert_expiry"       url:"alert_reminder,omitempty"`
+	AlertBroken    bool                `json:"alert_broken"       url:"alert_broken,omitempty"`
+	AlertMixed     bool                `json:"alert_mixed"        url:"alert_mixed,omitempty"`
+	Paused         bool                `json:"paused"`
+	IssuerCn       string              `json:"issuer_cn"`
+	CertScore      string              `json:"cert_score"`
+	CipherScore    string              `json:"cipher_score"`
+	CertStatus     string              `json:"cert_status"`
+	Cipher         string              `json:"cipher"`
+	ValidFromUtc   string              `json:"valid_from_utc"`
+	ValidUntilUtc  string              `json:"valid_until_utc"`
+	MixedContent   []map[string]string `json:"mixed_content"`
+	Flags          map[string]bool     `json:"flags"`
+	ContactGroups  []string            `json:"contact_groups"`
+	LastReminder   int                 `json:"last_reminder"`
+	LastUpdatedUtc string              `json:"last_updated_utc"`
+}
+
+//PartialSsl represent  a ssl test creation or modification
+type PartialSsl struct {
+	ID             int
+	Domain         string
+	Checkrate      string
+	ContactGroupsC string
+	AlertAt        string
+	AlertExpiry    bool
+	AlertReminder  bool
+	AlertBroken    bool
+	AlertMixed     bool
+}
+
+type createSsl struct {
+	ID             int              `url:"id,omitempty"`
+	Domain         string           `url:"domain"         json:"domain"`
+	Checkrate      jsonNumberString `url:"checkrate"      json:"checkrate"`
+	ContactGroupsC string           `url:"contact_groups" json:"contact_groups"`
+	AlertAt        string           `url:"alert_at"       json:"alert_at"`
+	AlertExpiry    bool             `url:"alert_expiry"   json:"alert_expiry"`
+	AlertReminder  bool             `url:"alert_reminder" json:"alert_reminder"`
+	AlertBroken    bool             `url:"alert_broken"   json:"alert_broken"`
+	AlertMixed     bool             `url:"alert_mixed"    json:"alert_mixed"`
+}
+
+func (cs *createSsl) fromPartial(p *PartialSsl) {
+	cs.ID = p.ID
+	cs.Domain = p.Domain
+	cs.Checkrate = jsonNumberString(p.Checkrate)
+	cs.ContactGroupsC = p.ContactGroupsC
+	cs.AlertAt = p.AlertAt
+	cs.AlertExpiry = p.AlertExpiry
+	cs.AlertReminder = p.AlertReminder
+	cs.AlertBroken = p.AlertBroken
+	cs.AlertMixed = p.AlertMixed
+}
+
+func (cs *createSsl) toPartial(p *PartialSsl) {
+	p.ID = cs.ID
+	p.Domain = cs.Domain
+	p.Checkrate = string(cs.Checkrate)
+	p.ContactGroupsC = cs.ContactGroupsC
+	p.AlertAt = cs.AlertAt
+	p.AlertExpiry = cs.AlertExpiry
+	p.AlertReminder = cs.AlertReminder
+	p.AlertBroken = cs.AlertBroken
+	p.AlertMixed = cs.AlertMixed
+}
+
+type updateSsl struct {
+	ID             int              `url:"id"`
+	Domain         string           `url:"domain"         json:"domain"`
+	Checkrate      jsonNumberString `url:"checkrate"      json:"checkrate"`
+	ContactGroupsC string           `url:"contact_groups" json:"contact_groups"`
+	AlertAt        string           `url:"alert_at"       json:"alert_at"`
+	AlertExpiry    bool             `url:"alert_expiry"   json:"alert_expiry"`
+	AlertReminder  bool             `url:"alert_reminder" json:"alert_reminder"`
+	AlertBroken    bool             `url:"alert_broken"   json:"alert_broken"`
+	AlertMixed     bool             `url:"alert_mixed"    json:"alert_mixed"`
+}
+
+func (us *updateSsl) fromPartial(p *PartialSsl) {
+	us.ID = p.ID
+	us.Domain = p.Domain
+	us.Checkrate = jsonNumberString(p.Checkrate)
+	us.ContactGroupsC = p.ContactGroupsC
+	us.AlertAt = p.AlertAt
+	us.AlertExpiry = p.AlertExpiry
+	us.AlertReminder = p.AlertReminder
+	us.AlertBroken = p.AlertBroken
+	us.AlertMixed = p.AlertMixed
+}
+
+func (us *updateSsl) toPartial(p *PartialSsl) {
+	p.ID = us.ID
+	p.Domain = us.Domain
+	p.Checkrate = string(us.Checkrate)
+	p.ContactGroupsC = us.ContactGroupsC
+	p.AlertAt = us.AlertAt
+	p.AlertExpiry = us.AlertExpiry
+	p.AlertReminder = us.AlertReminder
+	p.AlertBroken = us.AlertBroken
+	p.AlertMixed = us.AlertMixed
+}
+
+type sslUpdateResponse struct {
+	Success bool        `json:"Success"`
+	Message interface{} `json:"Message"`
+}
+
+type sslCreateResponse struct {
+	Success bool        `json:"Success"`
+	Message interface{} `json:"Message"`
+	Input   createSsl   `json:"Input"`
+}
+
+//Ssls represent the actions done wit the API
+type Ssls interface {
+	All() ([]*Ssl, error)
+	completeSsl(*PartialSsl) (*Ssl, error)
+	Detail(string) (*Ssl, error)
+	Update(*PartialSsl) (*Ssl, error)
+	UpdatePartial(*PartialSsl) (*PartialSsl, error)
+	Delete(ID string) error
+	CreatePartial(*PartialSsl) (*PartialSsl, error)
+	Create(*PartialSsl) (*Ssl, error)
+}
+
+func consolidateSsl(s *Ssl) {
+	(*s).ContactGroupsC = strings.Trim(strings.Join(strings.Fields(fmt.Sprint((*s).ContactGroups)), ","), "[]")
+}
+
+func findSsl(responses []*Ssl, id string) (*Ssl, error) {
+	var response *Ssl
+	for _, elem := range responses {
+		if (*elem).ID == id {
+			return elem, nil
+		}
+	}
+	return response, fmt.Errorf("%s Not found", id)
+}
+
+func (tt *ssls) completeSsl(s *PartialSsl) (*Ssl, error) {
+	full, err := tt.Detail(strconv.Itoa((*s).ID))
+	if err != nil {
+		return nil, err
+	}
+	(*full).ContactGroups = strings.Split((*s).ContactGroupsC, ",")
+	return full, nil
+}
+
+//Partial return a PartialSsl corresponding to the Ssl
+func Partial(s *Ssl) (*PartialSsl, error) {
+	if s == nil {
+		return nil, fmt.Errorf("s is nil")
+	}
+	id, err := strconv.Atoi(s.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &PartialSsl{
+		ID:             id,
+		Domain:         s.Domain,
+		Checkrate:      strconv.Itoa(s.Checkrate),
+		ContactGroupsC: s.ContactGroupsC,
+		AlertReminder:  s.AlertReminder,
+		AlertExpiry:    s.AlertExpiry,
+		AlertBroken:    s.AlertBroken,
+		AlertMixed:     s.AlertMixed,
+		AlertAt:        s.AlertAt,
+	}, nil
+
+}
+
+type ssls struct {
+	client apiClient
+}
+
+//NewSsls return a new ssls
+func NewSsls(c apiClient) Ssls {
+	return &ssls{
+		client: c,
+	}
+}
+
+//All return a list of all the ssl from the API
+func (tt *ssls) All() ([]*Ssl, error) {
+	rawResponse, err := tt.client.get("/SSL", nil)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting StatusCake Ssl: %s", err.Error())
+	}
+	var getResponse []*Ssl
+	err = json.NewDecoder(rawResponse.Body).Decode(&getResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	for ssl := range getResponse {
+		consolidateSsl(getResponse[ssl])
+	}
+
+	return getResponse, err
+}
+
+//Detail return the ssl corresponding to the id
+func (tt *ssls) Detail(id string) (*Ssl, error) {
+	responses, err := tt.All()
+	if err != nil {
+		return nil, err
+	}
+	mySsl, errF := findSsl(responses, id)
+	if errF != nil {
+		return nil, errF
+	}
+	return mySsl, nil
+}
+
+//Update update the API with s and create one if s.ID=0 then return the corresponding Ssl
+func (tt *ssls) Update(s *PartialSsl) (*Ssl, error) {
+	var err error
+	s, err = tt.UpdatePartial(s)
+	if err != nil {
+		return nil, err
+	}
+	return tt.completeSsl(s)
+}
+
+//UpdatePartial update the API with s and create one if s.ID=0 then return the corresponding PartialSsl
+func (tt *ssls) UpdatePartial(s *PartialSsl) (*PartialSsl, error) {
+	if (*s).ID == 0 {
+		return tt.CreatePartial(s)
+	}
+
+	var v url.Values
+	{
+		us := updateSsl{}
+		us.fromPartial(s)
+		v, _ = query.Values(us)
+	}
+
+	rawResponse, err := tt.client.put("/SSL/Update", v)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating StatusCake Ssl: %s", err.Error())
+	}
+
+	var updateResponse sslUpdateResponse
+	err = json.NewDecoder(rawResponse.Body).Decode(&updateResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if !updateResponse.Success {
+		return nil, fmt.Errorf("%s", updateResponse.Message.(string))
+	}
+
+	return s, nil
+}
+
+//Delete delete the ssl which ID is id
+func (tt *ssls) Delete(id string) error {
+	_, err := tt.client.delete("/SSL/Update", url.Values{"id": {fmt.Sprint(id)}})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//Create create the ssl whith the data in s and return the Ssl created
+func (tt *ssls) Create(s *PartialSsl) (*Ssl, error) {
+	var err error
+	s, err = tt.CreatePartial(s)
+	if err != nil {
+		return nil, err
+	}
+	return tt.completeSsl(s)
+}
+
+//CreatePartial create the ssl whith the data in s and return the PartialSsl created
+func (tt *ssls) CreatePartial(s *PartialSsl) (*PartialSsl, error) {
+	(*s).ID = 0
+	var v url.Values
+	{
+		cs := createSsl{}
+		cs.fromPartial(s)
+		v, _ = query.Values(cs)
+	}
+
+	rawResponse, err := tt.client.put("/SSL/Update", v)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating StatusCake Ssl: %s", err.Error())
+	}
+
+	var createResponse sslCreateResponse
+	err = json.NewDecoder(rawResponse.Body).Decode(&createResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if !createResponse.Success {
+		return nil, fmt.Errorf("%s", createResponse.Message.(string))
+	}
+	createResponse.Input.toPartial(s)
+	(*s).ID = int(createResponse.Message.(float64))
+
+	return s, nil
+}

--- a/vendor/github.com/DreamItGetIT/statuscake/tests.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/tests.go
@@ -99,13 +99,16 @@ type Test struct {
 	TestTags []string `json:"TestTags" querystring:"TestTags"`
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
-	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
+	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes" querystringoptions:"omitempty"`
 
 	// Set to 1 to enable the Cookie Jar. Required for some redirects.
 	UseJar int `json:"UseJar" querystring:"UseJar"`
 
 	// Raw POST data seperated by an ampersand
 	PostRaw string `json:"PostRaw" querystring:"PostRaw"`
+
+	// POST Body data, json
+	PostBody string `json:"PostBody" querystring:"PostBody"`
 
 	// Use to specify the expected Final URL in the testing process
 	FinalEndpoint string `json:"FinalEndpoint" querystring:"FinalEndpoint"`
@@ -115,6 +118,12 @@ type Test struct {
 
 	// Use to specify whether redirects should be followed
 	FollowRedirect bool `json:"FollowRedirect" querystring:"FollowRedirect"`
+
+	// DNS Tests only. Hostname or IP of DNS server to use.
+	DNSServer string `json:"DNSServer" querystring:"DNSServer"`
+
+	// DNS Tests only. IP to compare against WebsiteURL value.
+	DNSIP string `json:"DNSIP" querystring:"DNSIP"`
 }
 
 // Validate checks if the Test is valid. If it's invalid, it returns a ValidationError with all invalid fields. It returns nil otherwise.
@@ -149,8 +158,8 @@ func (t *Test) Validate() error {
 		e["Virus"] = "must be 0 or 1"
 	}
 
-	if t.TestType != "HTTP" && t.TestType != "TCP" && t.TestType != "PING" {
-		e["TestType"] = "must be HTTP, TCP, or PING"
+	if t.TestType != "HTTP" && t.TestType != "TCP" && t.TestType != "PING" && t.TestType != "DNS" {
+		e["TestType"] = "must be HTTP, TCP, DNS or PING"
 	}
 
 	if t.RealBrowser < 0 || t.RealBrowser > 1 {
@@ -162,11 +171,27 @@ func (t *Test) Validate() error {
 	}
 
 	if t.PostRaw != "" && t.TestType != "HTTP" {
-		e["PostRaw"] = "must be HTTP to submit a POST request"
+		e["PostRaw"] = "must be HTTP to submit a POST request with PostRaw"
+	}
+
+	if t.PostBody != "" && t.TestType != "HTTP" {
+		e["PostBody"] = "must be HTTP to submit a POST request with PostBody"
 	}
 
 	if t.FinalEndpoint != "" && t.TestType != "HTTP" {
 		e["FinalEndpoint"] = "must be a Valid URL"
+	}
+
+	if t.TestType == "DNS" && t.DNSIP == "" {
+		e["DNSIP"] = "is required"
+	}
+
+	if t.DNSServer != "" && t.TestType != "DNS" {
+		e["DNSServer"] = "must be only used for DNS type tests"
+	}
+
+	if t.DNSIP != "" && t.TestType != "DNS" {
+		e["DNSIP"] = "must be only used for DNS type tests"
 	}
 
 	if t.CustomHeader != "" {

--- a/vendor/github.com/DreamItGetIT/statuscake/types.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/types.go
@@ -1,0 +1,61 @@
+package statuscake
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+type jsonNumberString string
+
+func (v *jsonNumberString) UnmarshalJSON(b []byte) error {
+	if err := v.unmarshalAsInt(b); err == nil {
+		return nil
+	}
+	if err := v.unmarshalAsString(b); err == nil {
+		return nil
+	}
+	return fmt.Errorf("cannot unmarshal value that is neither a number nor a string: %s", truncate(b, 30))
+}
+
+func (v *jsonNumberString) unmarshalAsInt(b []byte) error {
+	if bytes.Equal(b, []byte(`null`)) {
+		return errors.New("cannot unmarshal JSON null to Go int")
+	}
+
+	var vv int
+	if err := json.Unmarshal(b, &vv); err != nil {
+		return err
+	}
+	*v = jsonNumberString(strconv.Itoa(vv))
+	return nil
+}
+
+func (v *jsonNumberString) unmarshalAsString(b []byte) error {
+	var vv string
+	if err := json.Unmarshal(b, &vv); err != nil {
+		return err
+	}
+	*v = jsonNumberString(vv)
+	return nil
+}
+
+const truncateEllipses = "..."
+
+func truncate(b []byte, max int) []byte {
+	lte := len(truncateEllipses)
+	min := lte + 3
+	if max < min {
+		max = min
+	}
+	if len(b) > max {
+		t := make([]byte, max)
+		n := max - lte
+		copy(t, b[0:n])
+		copy(t[n:], truncateEllipses)
+		return t
+	}
+	return b
+}

--- a/vendor/github.com/google/go-querystring/LICENSE
+++ b/vendor/github.com/google/go-querystring/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Google. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/google/go-querystring/query/encode.go
+++ b/vendor/github.com/google/go-querystring/query/encode.go
@@ -1,0 +1,320 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package query implements encoding of structs into URL query parameters.
+//
+// As a simple example:
+//
+// 	type Options struct {
+// 		Query   string `url:"q"`
+// 		ShowAll bool   `url:"all"`
+// 		Page    int    `url:"page"`
+// 	}
+//
+// 	opt := Options{ "foo", true, 2 }
+// 	v, _ := query.Values(opt)
+// 	fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2"
+//
+// The exact mapping between Go values and url.Values is described in the
+// documentation for the Values() function.
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+var encoderType = reflect.TypeOf(new(Encoder)).Elem()
+
+// Encoder is an interface implemented by any type that wishes to encode
+// itself into URL values in a non-standard way.
+type Encoder interface {
+	EncodeValues(key string, v *url.Values) error
+}
+
+// Values returns the url.Values encoding of v.
+//
+// Values expects to be passed a struct, and traverses it recursively using the
+// following encoding rules.
+//
+// Each exported struct field is encoded as a URL parameter unless
+//
+//	- the field's tag is "-", or
+//	- the field is empty and its tag specifies the "omitempty" option
+//
+// The empty values are false, 0, any nil pointer or interface value, any array
+// slice, map, or string of length zero, and any time.Time that returns true
+// for IsZero().
+//
+// The URL parameter name defaults to the struct field name but can be
+// specified in the struct field's tag value.  The "url" key in the struct
+// field's tag value is the key name, followed by an optional comma and
+// options.  For example:
+//
+// 	// Field is ignored by this package.
+// 	Field int `url:"-"`
+//
+// 	// Field appears as URL parameter "myName".
+// 	Field int `url:"myName"`
+//
+// 	// Field appears as URL parameter "myName" and the field is omitted if
+// 	// its value is empty
+// 	Field int `url:"myName,omitempty"`
+//
+// 	// Field appears as URL parameter "Field" (the default), but the field
+// 	// is skipped if empty.  Note the leading comma.
+// 	Field int `url:",omitempty"`
+//
+// For encoding individual field values, the following type-dependent rules
+// apply:
+//
+// Boolean values default to encoding as the strings "true" or "false".
+// Including the "int" option signals that the field should be encoded as the
+// strings "1" or "0".
+//
+// time.Time values default to encoding as RFC3339 timestamps.  Including the
+// "unix" option signals that the field should be encoded as a Unix time (see
+// time.Unix())
+//
+// Slice and Array values default to encoding as multiple URL values of the
+// same name.  Including the "comma" option signals that the field should be
+// encoded as a single comma-delimited value.  Including the "space" option
+// similarly encodes the value as a single space-delimited string. Including
+// the "semicolon" option will encode the value as a semicolon-delimited string.
+// Including the "brackets" option signals that the multiple URL values should
+// have "[]" appended to the value name. "numbered" will append a number to
+// the end of each incidence of the value name, example:
+// name0=value0&name1=value1, etc.
+//
+// Anonymous struct fields are usually encoded as if their inner exported
+// fields were fields in the outer struct, subject to the standard Go
+// visibility rules.  An anonymous struct field with a name given in its URL
+// tag is treated as having that name, rather than being anonymous.
+//
+// Non-nil pointer values are encoded as the value pointed to.
+//
+// Nested structs are encoded including parent fields in value names for
+// scoping. e.g:
+//
+// 	"user[name]=acme&user[addr][postcode]=1234&user[addr][city]=SFO"
+//
+// All other values are encoded using their default string representation.
+//
+// Multiple fields that encode to the same URL parameter name will be included
+// as multiple URL values of the same name.
+func Values(v interface{}) (url.Values, error) {
+	values := make(url.Values)
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return values, nil
+		}
+		val = val.Elem()
+	}
+
+	if v == nil {
+		return values, nil
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("query: Values() expects struct input. Got %v", val.Kind())
+	}
+
+	err := reflectValue(values, val, "")
+	return values, err
+}
+
+// reflectValue populates the values parameter from the struct fields in val.
+// Embedded structs are followed recursively (using the rules defined in the
+// Values function documentation) breadth-first.
+func reflectValue(values url.Values, val reflect.Value, scope string) error {
+	var embedded []reflect.Value
+
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		sf := typ.Field(i)
+		if sf.PkgPath != "" && !sf.Anonymous { // unexported
+			continue
+		}
+
+		sv := val.Field(i)
+		tag := sf.Tag.Get("url")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseTag(tag)
+		if name == "" {
+			if sf.Anonymous && sv.Kind() == reflect.Struct {
+				// save embedded struct for later processing
+				embedded = append(embedded, sv)
+				continue
+			}
+
+			name = sf.Name
+		}
+
+		if scope != "" {
+			name = scope + "[" + name + "]"
+		}
+
+		if opts.Contains("omitempty") && isEmptyValue(sv) {
+			continue
+		}
+
+		if sv.Type().Implements(encoderType) {
+			if !reflect.Indirect(sv).IsValid() {
+				sv = reflect.New(sv.Type().Elem())
+			}
+
+			m := sv.Interface().(Encoder)
+			if err := m.EncodeValues(name, &values); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sv.Kind() == reflect.Slice || sv.Kind() == reflect.Array {
+			var del byte
+			if opts.Contains("comma") {
+				del = ','
+			} else if opts.Contains("space") {
+				del = ' '
+			} else if opts.Contains("semicolon") {
+				del = ';'
+			} else if opts.Contains("brackets") {
+				name = name + "[]"
+			}
+
+			if del != 0 {
+				s := new(bytes.Buffer)
+				first := true
+				for i := 0; i < sv.Len(); i++ {
+					if first {
+						first = false
+					} else {
+						s.WriteByte(del)
+					}
+					s.WriteString(valueString(sv.Index(i), opts))
+				}
+				values.Add(name, s.String())
+			} else {
+				for i := 0; i < sv.Len(); i++ {
+					k := name
+					if opts.Contains("numbered") {
+						k = fmt.Sprintf("%s%d", name, i)
+					}
+					values.Add(k, valueString(sv.Index(i), opts))
+				}
+			}
+			continue
+		}
+
+		for sv.Kind() == reflect.Ptr {
+			if sv.IsNil() {
+				break
+			}
+			sv = sv.Elem()
+		}
+
+		if sv.Type() == timeType {
+			values.Add(name, valueString(sv, opts))
+			continue
+		}
+
+		if sv.Kind() == reflect.Struct {
+			reflectValue(values, sv, name)
+			continue
+		}
+
+		values.Add(name, valueString(sv, opts))
+	}
+
+	for _, f := range embedded {
+		if err := reflectValue(values, f, scope); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// valueString returns the string representation of a value.
+func valueString(v reflect.Value, opts tagOptions) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Bool && opts.Contains("int") {
+		if v.Bool() {
+			return "1"
+		}
+		return "0"
+	}
+
+	if v.Type() == timeType {
+		t := v.Interface().(time.Time)
+		if opts.Contains("unix") {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		return t.Format(time.RFC3339)
+	}
+
+	return fmt.Sprint(v.Interface())
+}
+
+// isEmptyValue checks if a value should be considered empty for the purposes
+// of omitting fields with the "omitempty" option.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	if v.Type() == timeType {
+		return v.Interface().(time.Time).IsZero()
+	}
+
+	return false
+}
+
+// tagOptions is the string following a comma in a struct field's "url" tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/DreamItGetIT/statuscake v0.0.0-20190218105717-471b24d8edfb
+# github.com/DreamItGetIT/statuscake v0.0.0-20201021084627-4e32615dcae9
 ## explicit
 github.com/DreamItGetIT/statuscake
 # github.com/agext/levenshtein v1.2.2
@@ -74,6 +74,8 @@ github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
+# github.com/google/go-querystring v1.0.0
+github.com/google/go-querystring/query
 # github.com/googleapis/gax-go/v2 v2.0.3
 github.com/googleapis/gax-go/v2
 # github.com/hashicorp/errwrap v1.0.0

--- a/website/docs/r/test.html.markdown
+++ b/website/docs/r/test.html.markdown
@@ -58,6 +58,8 @@ The following arguments are supported:
 * `final_endpoint` - (Optional) Use to specify the expected Final URL in the testing process.
 * `enable_ssl_alert` - (Optional) HTTP Tests only. If enabled, tests will send warnings if the SSL certificate is about to expire. Paid users only. Default is false
 * `follow_redirect` - (Optional) Use to specify whether redirects should be followed, set to true to enable. Default is false.
+* `dns_server` - (Optional) *Used only for DNS type tests* Hostname or IP of DNS server to use.
+* `dns_ip` - (Optional) *Used only for DNS type tests* Comma-separated IPs to compare against the `website_url` resolved value.
 
 ## Attributes Reference
 


### PR DESCRIPTION
With this PR I'm adding support for two additional fields, `dns_server` and `dns_ip` that the API needs to actually implement tests of type `DNS`.
The descriptions in the documentation have been fetched from [the API page](https://www.statuscake.com/api/Tests/Updating%20Inserting%20and%20Deleting%20Tests.md). 

This would close https://github.com/StatusCakeDev/terraform-provider-statuscake/issues/24.